### PR TITLE
fix TypeError if path /constructor/foo is accessed

### DIFF
--- a/lib/segment.js
+++ b/lib/segment.js
@@ -174,7 +174,7 @@ internals.Segment.prototype.lookup = function (path, segments, options) {
     const remainder = (segments.length > 1 ? segments.slice(1) : null);
 
     if (this._literals) {
-        var literal = options.isCaseSensitive ? current : current.toLowerCase();
+        let literal = options.isCaseSensitive ? current : current.toLowerCase();
         match = this._literals.hasOwnProperty(literal) && this._literals[literal];
         if (match) {
             const record = internals.deeper(match, nextPath, remainder, [], options);

--- a/lib/segment.js
+++ b/lib/segment.js
@@ -174,7 +174,7 @@ internals.Segment.prototype.lookup = function (path, segments, options) {
     const remainder = (segments.length > 1 ? segments.slice(1) : null);
 
     if (this._literals) {
-        let literal = options.isCaseSensitive ? current : current.toLowerCase();
+        const literal = options.isCaseSensitive ? current : current.toLowerCase();
         match = this._literals.hasOwnProperty(literal) && this._literals[literal];
         if (match) {
             const record = internals.deeper(match, nextPath, remainder, [], options);

--- a/lib/segment.js
+++ b/lib/segment.js
@@ -174,7 +174,8 @@ internals.Segment.prototype.lookup = function (path, segments, options) {
     const remainder = (segments.length > 1 ? segments.slice(1) : null);
 
     if (this._literals) {
-        match = this._literals[options.isCaseSensitive ? current : current.toLowerCase()];
+        var literal = options.isCaseSensitive ? current : current.toLowerCase();
+        match = this._literals.hasOwnProperty(literal) && this._literals[literal];
         if (match) {
             const record = internals.deeper(match, nextPath, remainder, [], options);
             if (record) {

--- a/test/index.js
+++ b/test/index.js
@@ -675,6 +675,15 @@ describe('Router', () => {
             expect(router.route('get', '/a/%p').output.statusCode).to.equal(400);
             done();
         });
+
+        it('fails to match js object prototype properties for literals', function (done) {
+
+            var router = new Call.Router();
+            router.add({ method: 'get', path: '/a/{b}' }, '/');
+            expect(router.route('get', '/constructor/').output.statusCode).to.equal(404);
+            expect(router.route('get', '/hasOwnProperty/').output.statusCode).to.equal(404);
+            done();
+        });
     });
 
     describe('normalize()', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -678,7 +678,7 @@ describe('Router', () => {
 
         it('fails to match js object prototype properties for literals', function (done) {
 
-            var router = new Call.Router();
+            const router = new Call.Router();
             router.add({ method: 'get', path: '/a/{b}' }, '/');
             expect(router.route('get', '/constructor/').output.statusCode).to.equal(404);
             expect(router.route('get', '/hasOwnProperty/').output.statusCode).to.equal(404);

--- a/test/index.js
+++ b/test/index.js
@@ -676,7 +676,7 @@ describe('Router', () => {
             done();
         });
 
-        it('fails to match js object prototype properties for literals', function (done) {
+        it('fails to match js object prototype properties for literals', (done)  => {
 
             const router = new Call.Router();
             router.add({ method: 'get', path: '/a/{b}' }, '/');


### PR DESCRIPTION
If there are any literals available in the router, then any access to a path with
multiple segments and its first segment an object prototype property, lead to a
TypeError.

This fixes these TypeErrors by checking whether the property is the literal list's own.

There is a similar code path for the `this._fulls` but the path always contains a leading slash,
thus is not vulnerable to such error.

```
Debug: internal, implementation, error
    TypeError: match.lookup is not a function
    at Object.internals.deeper (/some-project/node_modules/hapi/node_modules/call/lib/segment.js:240:28)
    at internals.Segment.lookup (/some-project/node_modules/hapi/node_modules/call/lib/segment.js:177:36)
    at internals.Router._lookup (/some-project/node_modules/hapi/node_modules/call/lib/index.js:113:28)
    at internals.Router.route (/some-project/node_modules/hapi/node_modules/call/lib/index.js:94:22)
    at internals.Request._lifecycle (/some-project/node_modules/hapi/lib/request.js:343:41)
    at internals.Request._execute (/some-project/node_modules/hapi/lib/request.js:312:21)
    at Domain.<anonymous> (/some-project/node_modules/hapi/lib/connection.js:253:25)
    at Domain.run (domain.js:191:14)
    at internals.Protect.enter (/some-project/node_modules/hapi/lib/protect.js:84:17)
    at Server.internals.Connection._dispatch (/some-project/node_modules/hapi/lib/connection.js:251:30)
```