### PR TITLE
Apply path segment normalization

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -172,6 +172,37 @@ internals.Router.prototype.normalize = function (path) {
         path = decoded;
     }
 
+    if (path &&
+        (path.indexOf('/.') !== -1 || path[0] === '.')) {
+
+        // Normalize path segments
+
+        const initialDash = path[0] === '/';
+        const segments = path.split('/');
+        const normalized = [];
+        let segment;
+
+        for (let i = 0; i < segments.length; ++i) {
+            segment = segments[i];
+            if (segment === '..') {
+                normalized.pop();
+            }
+            else if (segment !== '.') {
+                normalized.push(segment);
+            }
+        }
+
+        if (segment === '.' || segment === '..') {     // Add trailing slash when needed
+            normalized.push('');
+        }
+
+        path = normalized.join('/');
+
+        if (path[0] !== '/' && initialDash) {
+            path = '/' + path;
+        }
+    }
+
     return path;
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -729,13 +729,6 @@ describe('Router', () => {
             done();
         });
 
-        it('returns empty path on empty', (done) => {
-
-            const router = new Call.Router();
-            expect(router.normalize('')).to.equal('');
-            done();
-        });
-
         it('applies path segment normalization', (done) => {
 
             const paths = {
@@ -748,6 +741,7 @@ describe('Router', () => {
                 './': '',
                 './/': '/',
                 '/foo/./bar': '/foo/bar',
+                '/foo/%2e/bar': '/foo/bar',
                 '/bar/.': '/bar/',
                 '/bar/./': '/bar/',
                 '/bar/..': '/',
@@ -760,7 +754,6 @@ describe('Router', () => {
                 '/../': '/',
                 '/.': '/',
                 '/./': '/',
-                '//': '//',
                 '//.': '//',
                 '//./': '//',
                 '//../': '/'
@@ -770,6 +763,34 @@ describe('Router', () => {
             const keys = Object.keys(paths);
             for (let i = 0; i < keys.length; ++i) {
                 expect(router.normalize(keys[i])).to.equal(paths[keys[i]]);
+            }
+
+            done();
+        });
+
+        it('does not transform specific paths', (done) => {
+
+            const paths = [
+                '',
+                '//',
+                '%2F',
+                '.bar',
+                '.bar/',
+                '.foo/bar',
+                'foo/.bar',
+                'foo/.bar/',
+                'foo/.bar/baz',
+                '/.bar',
+                '/.bar/',
+                '/.foo/bar',
+                '/foo/.bar',
+                '/foo/.bar/',
+                '/foo/.bar/baz'
+            ];
+
+            const router = new Call.Router();
+            for (let i = 0; i < paths.length; ++i) {
+                expect(router.normalize(paths[i])).to.equal(paths[i]);
             }
 
             done();

--- a/test/index.js
+++ b/test/index.js
@@ -735,6 +735,45 @@ describe('Router', () => {
             expect(router.normalize('')).to.equal('');
             done();
         });
+
+        it('applies path segment normalization', (done) => {
+
+            const paths = {
+                './bar': 'bar',
+                '../bar': 'bar',
+                '.././bar': 'bar',
+                'foo/bar/..': 'foo/',
+                '..': '',
+                '.': '',
+                './': '',
+                './/': '/',
+                '/foo/./bar': '/foo/bar',
+                '/bar/.': '/bar/',
+                '/bar/./': '/bar/',
+                '/bar/..': '/',
+                '/bar/../': '/',
+                '/bar/../.': '/',
+                '/foo/../bar': '/bar',
+                '/foo/./../bar': '/bar',
+                '/foo/bar/..': '/foo/',
+                '/..': '/',
+                '/../': '/',
+                '/.': '/',
+                '/./': '/',
+                '//': '//',
+                '//.': '//',
+                '//./': '//',
+                '//../': '/'
+            };
+
+            const router = new Call.Router();
+            const keys = Object.keys(paths);
+            for (let i = 0; i < keys.length; ++i) {
+                expect(router.normalize(keys[i])).to.equal(paths[keys[i]]);
+            }
+
+            done();
+        });
     });
 
     describe('analyze()', () => {


### PR DESCRIPTION
This implements path segment normalization discussed in #28.

I don't use the algorithm [defined in the spec](https://tools.ietf.org/html/rfc3986#section-5.2.4), but a segment based one, which I suspect will be faster for most use cases.

I have gated the algorithm behind a simple pre-detection `if` case, causing it to not be executed for something like 99% of URLs.

I have also added a somewhat comprehensive test suite, testing many of the edge cases. I also tested this new logic with `hapi`, which still passes the test suite. I encountered 2 failing tests with `inert`. In both cases the test expected a `403` but got at `404` instead, due to no longer matching the tested route (as expected). I don't consider this an issue, and I can rework the tests to handle the new logic.