### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,6 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2014, Walmart.  
+Copyright (c) 2014-2022, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
+Copyright (c) 2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ internals.Router.prototype.add = function (config, route) {
 
     const vhost = config.vhost || '*';
     if (vhost !== '*') {
-        this.vhosts = this.vhosts || new Map();
+        this.vhosts = this.vhosts ?? new Map();
         if (!this.vhosts.has(vhost)) {
             this.vhosts.set(vhost, new Map());
         }
@@ -49,7 +49,7 @@ internals.Router.prototype.add = function (config, route) {
         table.set(method, { routes: [], router: new Segment() });
     }
 
-    const analysis = config.analysis || this.analyze(config.path);
+    const analysis = config.analysis ?? this.analyze(config.path);
     const record = {
         path: config.path,
         route: route || config.path,
@@ -124,7 +124,7 @@ internals.Router.prototype._lookup = function (path, segments, table, method) {
         const name = match.record.params[i];
         const value = Decode.decode(match.array[i]);
         if (value === null) {
-            return this.specials.badRequest || Boom.badRequest('Invalid request path');
+            return this.specials.badRequest ?? Boom.badRequest('Invalid request path');
         }
 
         if (assignments[name] !== undefined) {

--- a/lib/segment.js
+++ b/lib/segment.js
@@ -38,20 +38,20 @@ internals.Segment.prototype.add = function (segments, record) {
     }
 
     if (isLiteral) {
-        this._fulls = this._fulls || new Map();
+        this._fulls = this._fulls ?? new Map();
         let literal = '/' + literals.join('/');
         if (!record.settings.isCaseSensitive) {
             literal = literal.toLowerCase();
         }
 
-        Hoek.assert(!this._fulls.has(literal), 'New route', record.path, 'conflicts with existing', this._fulls.has(literal) && this._fulls.get(literal).record.path);
+        Hoek.assert(!this._fulls.has(literal), 'New route', record.path, 'conflicts with existing', this._fulls.get(literal)?.record.path);
         this._fulls.set(literal, { segment: current, record });
     }
     else if (current.literal !== undefined) {               // Can be empty string
 
         // Literal
 
-        this._literals = this._literals || new Map();
+        this._literals = this._literals ?? new Map();
         const currentLiteral = record.settings.isCaseSensitive ? current.literal : current.literal.toLowerCase();
         if (!this._literals.has(currentLiteral)) {
             this._literals.set(currentLiteral, new internals.Segment());
@@ -63,15 +63,15 @@ internals.Segment.prototype.add = function (segments, record) {
 
         // Wildcard
 
-        Hoek.assert(!this._wildcard, 'New route', record.path, 'conflicts with existing', this._wildcard && this._wildcard.record.path);
-        Hoek.assert(!this._param || !this._param._wildcard, 'New route', record.path, 'conflicts with existing', this._param && this._param._wildcard && this._param._wildcard.record.path);
+        Hoek.assert(!this._wildcard, 'New route', record.path, 'conflicts with existing', this._wildcard?.record.path);
+        Hoek.assert(!this._param || !this._param._wildcard, 'New route', record.path, 'conflicts with existing', this._param?._wildcard?.record.path);
         this._wildcard = { segment: current, record };
     }
     else if (current.mixed) {
 
         // Mixed
 
-        this._mixed = this._mixed || [];
+        this._mixed = this._mixed ?? [];
 
         let mixed = this._mixedLookup(current);
         if (!mixed) {
@@ -81,7 +81,7 @@ internals.Segment.prototype.add = function (segments, record) {
         }
 
         if (isEdge) {
-            Hoek.assert(!mixed.node._edge, 'New route', record.path, 'conflicts with existing', mixed.node._edge && mixed.node._edge.record.path);
+            Hoek.assert(!mixed.node._edge, 'New route', record.path, 'conflicts with existing', mixed.node._edge?.record.path);
             mixed.node._edge = { segment: current, record };
         }
         else {
@@ -92,14 +92,14 @@ internals.Segment.prototype.add = function (segments, record) {
 
         // Parameter
 
-        this._param = this._param || new internals.Segment();
+        this._param = this._param ?? new internals.Segment();
 
         if (isEdge) {
-            Hoek.assert(!this._param._edge, 'New route', record.path, 'conflicts with existing', this._param._edge && this._param._edge.record.path);
+            Hoek.assert(!this._param._edge, 'New route', record.path, 'conflicts with existing', this._param._edge?.record.path);
             this._param._edge = { segment: current, record };
         }
         else {
-            Hoek.assert(!this._wildcard || !remaining[0].wildcard, 'New route', record.path, 'conflicts with existing', this._wildcard && this._wildcard.record.path);
+            Hoek.assert(!this._wildcard || !remaining[0].wildcard, 'New route', record.path, 'conflicts with existing', this._wildcard?.record.path);
             this._param.add(remaining, record);
         }
     }
@@ -206,9 +206,7 @@ internals.Segment.prototype.lookup = function (path, segments, options) {
     // Param
 
     if (this._param) {
-        if (current ||
-            this._param._edge && this._param._edge.segment.empty) {
-
+        if (current || this._param._edge?.segment.empty) {
             const record = internals.deeper(this._param, nextPath, remainder, [current], options);
             if (record) {
                 return record;

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@hapi/hoek": "^10.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "^8.0.0",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
     "@hapi/lab": "^25.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/hoek": "9.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/hoek": "^10.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^8.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "^25.0.1"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L",


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules.

If this looks good, this will go out as call v9.